### PR TITLE
Edit pg_hba.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#22] Allow connections from all nodes of a cluster (cidr /16) in kubernetes environments.
 
 ## [v12.14-2] - 2023-04-21
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN set -x -o errexit \
 FROM registry.cloudogu.com/official/base:3.17.3-2
 
 LABEL NAME="official/postgresql" \
-        VERSION="12.14-2" \
+        VERSION="12.15-1" \
         maintainer="hello@cloudogu.com"
 
 ENV LANG=en_US.utf8 \
     PGDATA=/var/lib/postgresql \
-    POSTGRESQL_VERSION=12.14-r0
+    POSTGRESQL_VERSION=12.15-r0
 
 # install postgresql and gosu
 # Note: the current postgresql version from alpine is installed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.64.1', 'github.com/cloudogu/dogu-build-lib@v2.0.0'])
+@Library(['github.com/cloudogu/ces-build-lib@1.65.0', 'github.com/cloudogu/dogu-build-lib@v2.1.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 


### PR DESCRIPTION
Allow connections from all nodes of a cluster (cidr /16) in kubernetes environments. The old configuration lead to accepted connection with cidr/32 in clouds from azure, google and plusserver.

Resolves #22 